### PR TITLE
Fixed broken URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Please save as csv with bill title as the file name.
 
 You can use [_Tabula_](http://tabula.technology/) to scrape the data.
 
-We need laws scraped from [_here_](http://www.lrc.ky.gov/record/17RS/passed.html). Use the goole doc form to sign up for laws to scrape that you can find [_here_](https://docs.google.com/spreadsheets/d/1PMZdOcgm7Yk8uzgqSR2lfeWB1qiUhiLhyGh0jgdyucA/edit#gid=0)
+We need laws scraped from [_here_](http://www.lrc.ky.gov/record/17RS/record.htm). Use the goole doc form to sign up for laws to scrape that you can find [_here_](https://docs.google.com/spreadsheets/d/1PMZdOcgm7Yk8uzgqSR2lfeWB1qiUhiLhyGh0jgdyucA/edit#gid=0)
 
 Please include the law name in your commit comments.
 


### PR DESCRIPTION
http://www.lrc.ky.gov/record/17RS/record.htm
(was passed.html, which could be fixed as passed.html, but record.htm seems more general)